### PR TITLE
Add pluralization rule to fa_IR.js.erb

### DIFF
--- a/app/assets/javascripts/locales/fa_IR.js.erb
+++ b/app/assets/javascripts/locales/fa_IR.js.erb
@@ -1,3 +1,7 @@
 //= depend_on 'client.fa_IR.yml'
 //= require locales/i18n
 <%= JsLocaleHelper.output_locale(:fa_IR) %>
+
+I18n.pluralizationRules['fa_IR'] = function (n) {
+   return "other";
+};


### PR DESCRIPTION
Persian does not distinguish between the singular and plural forms
of nouns in the same way as English does. For numbered elements,
always return the 'other' key from the translation file.